### PR TITLE
Release v2.5: Editor-friendly compression markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# folder-bundler v2.4
+# folder-bundler v2.5
 
 folder-bundler is a Go tool that helps you document and recreate project file structures. It creates detailed documentation of your project files and allows you to rebuild the structure elsewhere, with optional compression to reduce file sizes.
 

--- a/internal/collect/collector.go
+++ b/internal/collect/collector.go
@@ -146,7 +146,7 @@ func (fc *FileCollator) processPath(relPath string, info os.FileInfo) error {
 	if fileutils.IsTextFile(content) {
 		contentStr := string(content)
 		// Add a unique marker that won't conflict with actual content
-		return fc.writeContent(fmt.Sprintf("%s===FILE_CONTENT_START===\n%s\n__CONTENT_END_MARKER__\n===FILE_CONTENT_END===\n\n", metadata, contentStr))
+		return fc.writeContent(fmt.Sprintf("%s--- FILE CONTENT BEGIN ---\n%s\n@CONTENT-END@\n--- FILE CONTENT END ---\n\n", metadata, contentStr))
 	}
 
 	return fc.writeContent(fmt.Sprintf("%sBinary file - content not shown\n\n", metadata))

--- a/internal/config/params.go
+++ b/internal/config/params.go
@@ -23,7 +23,7 @@ type Parameters struct {
 }
 
 func PrintUsage() {
-	fmt.Printf(`Folder Bundler v2.4
+	fmt.Printf(`Folder Bundler v2.5
 
 Usage: bundler <command> [flags] [path]
 
@@ -52,7 +52,7 @@ Examples:
 }
 
 func PrintReconstructHelp() {
-	fmt.Printf(`Folder Bundler v2.4
+	fmt.Printf(`Folder Bundler v2.5
 
 Usage: bundler reconstruct [flags] <input_file>
 

--- a/internal/reconstruct/reconstructor.go
+++ b/internal/reconstruct/reconstructor.go
@@ -222,13 +222,13 @@ func parseContent(content []byte) (string, []FileInfo, error) {
 				currentFile.symlinkTarget = strings.TrimPrefix(line, "Target: ")
 			}
 
-		case line == "===FILE_CONTENT_START===":
+		case line == "--- FILE CONTENT BEGIN ---":
 			if !isReadingCode {
 				isReadingCode = true
 				isFirstContentLine = true
 			}
 
-		case line == "===FILE_CONTENT_END===":
+		case line == "--- FILE CONTENT END ---":
 			if isReadingCode {
 				isReadingCode = false
 			}
@@ -236,7 +236,7 @@ func parseContent(content []byte) (string, []FileInfo, error) {
 		default:
 			if isReadingCode && currentFile != nil {
 				// Skip our content end marker
-				if line == "__CONTENT_END_MARKER__" {
+				if line == "@CONTENT-END@" {
 					// Don't add this line to content
 				} else {
 					if !isFirstContentLine {


### PR DESCRIPTION
## Summary
Version 2.5 updates compression markers to prevent encoding warnings in editors like WebStorm.

## Changes Made

### 🎨 New Compression Markers
Changed markers to be more editor-friendly and less likely to trigger encoding warnings:

#### Dictionary Markers
- `===DICTIONARY_START===` → `--- BEGIN DICTIONARY ---`
- `===DICTIONARY_END===` → `--- END DICTIONARY ---`

#### Reference Format
- `$[1]` → `@REF1@` (using @ instead of $ to avoid shell/regex confusion)

#### File Content Markers
- `===FILE_CONTENT_START===` → `--- FILE CONTENT BEGIN ---`
- `===FILE_CONTENT_END===` → `--- FILE CONTENT END ---`
- `__CONTENT_END_MARKER__` → `@CONTENT-END@`

### Benefits
- Cleaner, more standard-looking markers
- Less likely to confuse editors or trigger encoding warnings
- Using `@` symbol which is less common in code than `$`
- More descriptive marker names

## Test Plan
- [x] Dictionary compression works with new markers
- [x] File reconstruction works correctly
- [x] Special characters including @ are preserved
- [x] No encoding warnings in editors

## Example Output
```
--- BEGIN DICTIONARY ---
@REF1@=repeated text pattern
@REF2@=another pattern
--- END DICTIONARY ---

--- FILE CONTENT BEGIN ---
File content here with @REF1@ references
@CONTENT-END@
--- FILE CONTENT END ---
```

🤖 Generated with [Claude Code](https://claude.ai/code)