### PR TITLE
Release v2.6: .fb extension and marker detection fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# folder-bundler v2.5
+# folder-bundler v2.6
 
 folder-bundler is a Go tool that helps you document and recreate project file structures. It creates detailed documentation of your project files and allows you to rebuild the structure elsewhere, with optional compression to reduce file sizes.
 
@@ -23,12 +23,12 @@ Document with compression:
 
 Recreate the structure elsewhere:
 ```bash
-./bundler reconstruct project_collated.md
+./bundler reconstruct project_collated_part1.fb
 ```
 
 ## Core Features
 
-The tool creates comprehensive project documentation including file contents, directory structures, and metadata. It handles text and binary files appropriately, supports syntax highlighting for major programming languages, and manages large projects through automatic file splitting.
+The tool creates comprehensive project documentation including file contents, directory structures, and metadata. Output files use the `.fb` extension (folder bundle) to avoid editor encoding issues. It handles text and binary files appropriately, supports syntax highlighting for major programming languages, and manages large projects through automatic file splitting.
 
 ### Compression Support
 

--- a/internal/collect/collector.go
+++ b/internal/collect/collector.go
@@ -103,7 +103,7 @@ func ProcessDirectory(params *config.Parameters) error {
 		fmt.Printf("\nCollection complete:\n")
 		fmt.Printf("  Files processed: %d\n", collator.fileCount)
 		fmt.Printf("  Total size: %s\n", formatSize(collator.totalSize))
-		fmt.Printf("  Output: %s_part*.md\n", collator.baseFileName)
+		fmt.Printf("  Output: %s_part*.fb\n", collator.baseFileName)
 	}
 
 	return err
@@ -179,7 +179,7 @@ func (fc *FileCollator) writeContent(content string) error {
 func (fc *FileCollator) createNewFile() error {
 	fc.closeCurrentFile()
 
-	fileName := fmt.Sprintf("%s_part%d.md", fc.baseFileName, fc.currentPart)
+	fileName := fmt.Sprintf("%s_part%d.fb", fc.baseFileName, fc.currentPart)
 	file, err := os.Create(fileName)
 	if err != nil {
 		return err
@@ -223,7 +223,7 @@ func (fc *FileCollator) finalizeWithCompression() error {
 	
 	// Create output file without header for compressed content
 	fc.closeCurrentFile()
-	fileName := fmt.Sprintf("%s_part%d.md", fc.baseFileName, fc.currentPart)
+	fileName := fmt.Sprintf("%s_part%d.fb", fc.baseFileName, fc.currentPart)
 	file, err := os.Create(fileName)
 	if err != nil {
 		return err

--- a/internal/compression/adapters/dictionary.go
+++ b/internal/compression/adapters/dictionary.go
@@ -216,9 +216,9 @@ func (d *DictionaryCompression) findPatterns(text string) []pattern {
 			
 			// Skip if contains our markers, delimiters, or newlines
 			if strings.Contains(substr, "--- BEGIN") || strings.Contains(substr, "--- END") ||
-			   strings.Contains(substr, "@REF") || strings.Contains(substr, "CONTENT-END") ||
-			   strings.Contains(substr, "FILE-CONTENT-BEGIN") ||
-			   strings.Contains(substr, "FILE-CONTENT-END") ||
+			   strings.Contains(substr, "@REF") || strings.Contains(substr, "@CONTENT-END@") ||
+			   strings.Contains(substr, "FILE CONTENT BEGIN") ||
+			   strings.Contains(substr, "FILE CONTENT END") ||
 			   strings.Contains(substr, "\n") {
 				continue
 			}

--- a/internal/config/params.go
+++ b/internal/config/params.go
@@ -23,7 +23,7 @@ type Parameters struct {
 }
 
 func PrintUsage() {
-	fmt.Printf(`Folder Bundler v2.5
+	fmt.Printf(`Folder Bundler v2.6
 
 Usage: bundler <command> [flags] [path]
 
@@ -47,12 +47,12 @@ Examples:
   bundler collect -compress auto myproject
   bundler collect -compress dictionary -max 5M myproject
   bundler collect myproject -max 1G -out-max 10M
-  bundler reconstruct myproject_collated_part1.md
+  bundler reconstruct myproject_collated_part1.fb
 `)
 }
 
 func PrintReconstructHelp() {
-	fmt.Printf(`Folder Bundler v2.5
+	fmt.Printf(`Folder Bundler v2.6
 
 Usage: bundler reconstruct [flags] <input_file>
 
@@ -60,7 +60,7 @@ Flags:
   -time  Preserve timestamps (default: true)
 
 Example:
-  bundler reconstruct myproject_collated_part1.md
+  bundler reconstruct myproject_collated_part1.fb
 `)
 }
 

--- a/internal/reconstruct/reconstructor.go
+++ b/internal/reconstruct/reconstructor.go
@@ -25,9 +25,9 @@ type FileInfo struct {
 func FromFile(inputFile string, params *config.Parameters) error {
 	fmt.Printf("Starting reconstruction from: %s\n", inputFile)
 	
-	basePath := strings.TrimSuffix(inputFile, "_part1.md")
-	basePath = strings.TrimSuffix(basePath, ".md")
-	pattern := basePath + "*.md"
+	basePath := strings.TrimSuffix(inputFile, "_part1.fb")
+	basePath = strings.TrimSuffix(basePath, ".fb")
+	pattern := basePath + "*.fb"
 
 	matches, err := filepath.Glob(pattern)
 	if err != nil {


### PR DESCRIPTION
## Summary
Version 2.6 changes the output file extension and fixes dictionary compression marker detection to resolve reconstruction issues.

## Changes Made

### 🎯 New File Extension: .fb
- Changed from `.md` to `.fb` (folder bundle)
- Prevents editors from trying to parse files as markdown
- Reduces encoding warnings in IDEs
- Clear indication that it's a folder bundle file

### 🔧 Fixed Dictionary Compression Markers
Fixed mismatch in marker detection that was causing reconstruction failures:
- `FILE-CONTENT-BEGIN` → `FILE CONTENT BEGIN`
- `FILE-CONTENT-END` → `FILE CONTENT END`
- `CONTENT-END` → `@CONTENT-END@`

This ensures dictionary patterns don't accidentally include our file markers.

### 📚 Documentation Updates
- Updated all examples to use `.fb` extension
- Updated help text
- Version bumped to 2.6

## Benefits
- No more "wrong encoding" warnings in WebStorm/IDEs
- Files are correctly identified as folder bundle files
- Dictionary compression works reliably without corruption
- Cleaner file type association

## Test Plan
- [x] Files created with `.fb` extension
- [x] Reconstruction finds `.fb` files correctly
- [x] Dictionary compression excludes markers properly
- [x] Unicode content preserved correctly
- [x] No encoding warnings in editors

## Example
```bash
# Collect with new extension
./bundler collect -compress auto myproject
# Creates: myproject_collated_part1.fb

# Reconstruct
./bundler reconstruct myproject_collated_part1.fb
```

🤖 Generated with [Claude Code](https://claude.ai/code)