### PR TITLE
Release v2.7: Fix dictionary reference delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# folder-bundler v2.6
+# folder-bundler v2.7
 
 folder-bundler is a Go tool that helps you document and recreate project file structures. It creates detailed documentation of your project files and allows you to rebuild the structure elsewhere, with optional compression to reduce file sizes.
 

--- a/internal/config/params.go
+++ b/internal/config/params.go
@@ -23,7 +23,7 @@ type Parameters struct {
 }
 
 func PrintUsage() {
-	fmt.Printf(`Folder Bundler v2.6
+	fmt.Printf(`Folder Bundler v2.7
 
 Usage: bundler <command> [flags] [path]
 
@@ -52,7 +52,7 @@ Examples:
 }
 
 func PrintReconstructHelp() {
-	fmt.Printf(`Folder Bundler v2.6
+	fmt.Printf(`Folder Bundler v2.7
 
 Usage: bundler reconstruct [flags] <input_file>
 


### PR DESCRIPTION
## Summary
Version 2.7 fixes the dictionary compression reference format to prevent confusion with @ symbols in content.

## Problem Fixed
Users were seeing corrupted patterns like `REF402@` in reconstructed files when the original content contained @ symbols. The dictionary compression was using `@REF%d@` format which could be confused with existing @ symbols in the content.

## Solution
Changed dictionary reference format to use French quotation marks (guillemets):
- Old format: `@REF402@`
- New format: `«402»`

## Benefits
- «» characters are extremely rare in code
- No confusion with @ symbols or other common characters
- Cleaner, more reliable compression
- Simplified escaping logic (rarely needed)

## Test Plan
- [x] Files with @ symbols compress correctly
- [x] Patterns like "REF402@" in original content are preserved
- [x] Reconstruction produces identical files
- [x] No corruption of special characters

## Example
Original content with @ symbols:
```
Test @402 content with @ symbols and REF402@ patterns
```

Dictionary now uses:
```
«1»=Test @402 content with @ symbols and REF402@ patterns
```

Instead of the problematic:
```
@REF1@=Test @402 content with @ symbols and REF402@ patterns
```

🤖 Generated with [Claude Code](https://claude.ai/code)