### PR TITLE
fix: handle large binary files with base64 line wrapping (v3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# folder-bundler v3.1
+# folder-bundler v3.2
 
 folder-bundler is a Go tool that helps you document and recreate project file structures. It creates detailed documentation of your project files and allows you to rebuild the structure elsewhere, with optional compression to reduce file sizes.
 
@@ -30,7 +30,7 @@ Recreate the structure elsewhere:
 
 The tool creates comprehensive project documentation including file contents, directory structures, and metadata. Output files use the `.fb` extension (folder bundle) to avoid editor encoding issues. 
 
-**Binary File Support (v3.1)**: Binary files (.ico, .jpg, .mp3, .wav, etc.) are automatically encoded to base64 for storage and decoded during reconstruction, ensuring perfect reproduction of all file types.
+**Binary File Support (v3.1+)**: Binary files (.ico, .jpg, .mp3, .wav, etc.) are automatically encoded to base64 for storage and decoded during reconstruction, ensuring perfect reproduction of all file types. Large files are handled with proper line wrapping (v3.2).
 
 The tool supports syntax highlighting for major programming languages, manages large projects through automatic file splitting, and calculates SHA-256 hashes for all files to ensure accurate reconstruction.
 
@@ -99,6 +99,12 @@ folder-bundler works well for:
 - Efficient code distribution
 
 ## Changelog
+
+### v3.2
+- **Fixed Large Binary File Support**: Resolved "token too long" error for large files
+  - Base64 output now wrapped at 76 characters per line
+  - Handles binary files of any size without scanner limitations
+  - Maintains backward compatibility with v3.1 files
 
 ### v3.1
 - **Binary File Support**: All binary files are now included in bundles

--- a/internal/collect/collector.go
+++ b/internal/collect/collector.go
@@ -156,9 +156,10 @@ func (fc *FileCollator) processPath(relPath string, info os.FileInfo) error {
 		return fc.writeContent(fmt.Sprintf("%s--- FILE CONTENT BEGIN ---\n%s\n@CONTENT-END@\n--- FILE CONTENT END ---\n\n", metadata, contentStr))
 	}
 
-	// Binary file - encode to base64
+	// Binary file - encode to base64 with line wrapping
 	encoded := base64.StdEncoding.EncodeToString(content)
-	return fc.writeContent(fmt.Sprintf("%s--- FILE CONTENT BEGIN (BASE64) ---\n%s\n@CONTENT-END@\n--- FILE CONTENT END ---\n\n", metadata, encoded))
+	wrapped := wrapBase64(encoded, 76)
+	return fc.writeContent(fmt.Sprintf("%s--- FILE CONTENT BEGIN (BASE64) ---\n%s\n@CONTENT-END@\n--- FILE CONTENT END ---\n\n", metadata, wrapped))
 }
 
 func (fc *FileCollator) writeContent(content string) error {
@@ -292,4 +293,24 @@ func formatSize(size int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(size)/float64(div), "KMGTPE"[exp])
+}
+
+// wrapBase64 wraps base64 string to specified line length
+func wrapBase64(s string, lineLength int) string {
+	if len(s) <= lineLength {
+		return s
+	}
+	
+	var result strings.Builder
+	for i := 0; i < len(s); i += lineLength {
+		end := i + lineLength
+		if end > len(s) {
+			end = len(s)
+		}
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		result.WriteString(s[i:end])
+	}
+	return result.String()
 }

--- a/internal/config/params.go
+++ b/internal/config/params.go
@@ -23,7 +23,7 @@ type Parameters struct {
 }
 
 func PrintUsage() {
-	fmt.Printf(`Folder Bundler v3.1
+	fmt.Printf(`Folder Bundler v3.2
 
 Usage: bundler <command> [flags] [path]
 
@@ -52,7 +52,7 @@ Examples:
 }
 
 func PrintReconstructHelp() {
-	fmt.Printf(`Folder Bundler v3.1
+	fmt.Printf(`Folder Bundler v3.2
 
 Usage: bundler reconstruct [flags] <input_file>
 

--- a/internal/reconstruct/reconstructor.go
+++ b/internal/reconstruct/reconstructor.go
@@ -396,8 +396,9 @@ func reconstructFileWithVerification(f FileInfo, preserveTimestamp bool) (bool, 
 	var fileContent []byte
 	
 	if f.isBase64 {
-		// Decode base64 content
-		decoded, err := base64.StdEncoding.DecodeString(content)
+		// Decode base64 content (remove newlines first)
+		cleanContent := strings.ReplaceAll(content, "\n", "")
+		decoded, err := base64.StdEncoding.DecodeString(cleanContent)
 		if err != nil {
 			return false, fmt.Errorf("error decoding base64 content: %v", err)
 		}


### PR DESCRIPTION
## Summary
- Fixed "bufio.Scanner: token too long" error for large binary files
- Base64 output now properly wrapped at 76 characters per line
- Version bumped to 3.2

## Problem
When processing large binary files (e.g., images, audio files), the base64 encoding created very long single lines that exceeded bufio.Scanner's default token size limit (64KB), causing reconstruction to fail with "token too long" error.

## Solution
1. Added `wrapBase64()` function to wrap encoded content at 76 characters per line
2. Modified reconstruction to strip newlines before base64 decoding
3. Maintains full compatibility with existing files

## Testing
- Tested with 100KB binary file
- Verified perfect reconstruction with SHA-256 matching
- No performance impact on smaller files

## Changes
- `collector.go`: Added line wrapping for base64 output
- `reconstructor.go`: Strip newlines before decoding
- Updated version to 3.2
- Added changelog entry

🤖 Generated with [Claude Code](https://claude.ai/code)